### PR TITLE
minor doc tweaks to say 'not commutative' where that was intended

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,7 +124,7 @@ recursively merged::
     > AttrDict(a) + b
     {'foo': 'bar', 'lorem': 'ipsum', 'alpha': {'beta': 'a', 'bravo': 'b', 'a': 'b'}}
 
-NOTE: AttrDict's add is not associative, ``a + b != b + a``::
+NOTE: AttrDict's add is not commutative, ``a + b != b + a``::
 
     > a = {'foo': 'bar', 'alpha': {'beta': 'b', 'a': 0}}
     > b = {'lorem': 'ipsum', 'alpha': {'bravo': 'b', 'a': 1}}

--- a/attrdict/__init__.py
+++ b/attrdict/__init__.py
@@ -224,7 +224,7 @@ class AttrDict(MutableMapping):
 
         Add a mapping to this AttrDict object.
 
-        NOTE: AttrDict is not idempotent. a + b != b + a.
+        NOTE: AttrDict is not commutative. a + b != b + a.
         """
         if not isinstance(other, Mapping):
             return NotImplemented
@@ -239,7 +239,7 @@ class AttrDict(MutableMapping):
 
         Add this AttrDict to a mapping object.
 
-        NOTE: AttrDict is not idempotent. a + b != b + a.
+        NOTE: AttrDict is not commutative. a + b != b + a.
         """
         if not isinstance(other, Mapping):
             return NotImplemented
@@ -349,7 +349,7 @@ def merge(left, right, recursive=True):
     recursive: (optional, True) Whether Sequences should have their
         elements turned into attrdicts.
 
-    NOTE: This is not idempotent. merge(a, b) != merge(b, a).
+    NOTE: This is not commutative. merge(a, b) != merge(b, a).
     """
     merged = AttrDict(recursive=recursive)
 


### PR DESCRIPTION
I think you meant 'not commutative' rather than 'not associative' and 'not idempotent' in the docs.
