### PR TITLE
Allow AttrDict to be pickled

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,3 +8,4 @@ v0.4.0, 2014/07/01 -- Happy Canada Day, have some defaultdict support
 v0.5.0, 2014/07/14 —- documentation fix (by @eukaryote), load function
 v0.5.1, 2014/07/14 -- tox for local testing, README fix, 0.5.0 no longer from the future
 v1.0.0, 2014/08/18 -- Development Status :: 5 - Production/Stable
+v1.1.0, 2014/11/26 -- Happy U.S. Thanksgiving, now you can pickle AttrDict! (by @jtratner)

--- a/attrdict/__init__.py
+++ b/attrdict/__init__.py
@@ -274,6 +274,14 @@ class AttrDict(MutableMapping):
                         default_factory=self._default_factory,
                         pass_key=self._pass_key)
 
+    def __getstate__(self):
+        return (self._mapping, self._recursive, self._default_factory,
+                self._pass_key)
+
+    def __setstate__(self, state):
+        mapping, recursive, default_factory, pass_key = state
+        self.__init__(mapping, recursive, default_factory, pass_key)
+
     @classmethod
     def _build(cls, obj, recursive=True):
         """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
 
 setup(
     name="attrdict",
-    version="1.0.0",
+    version="1.1.0",
     author="Brendan Curran-Johnson",
     author_email="brendan@bcjbcj.ca",
     packages=["attrdict"],


### PR DESCRIPTION
Previously, pickling would fail out with a recursion error (I believe because the code always assumed that certain properties were present and, on setting `__dict__` in the unpickle, that caused an infinite loop). This defines a custom pickle to make things work as you'd expect. Since pickling could not work previously, this isn't a backwards-incompatible change.

Please tell me if you want me to change any formatting here or there or if you want any other changes for coding standards.
