### PR TITLE
change __repr__ return value

### DIFF
--- a/attrdict/__init__.py
+++ b/attrdict/__init__.py
@@ -244,7 +244,7 @@ class AttrDict(MutableMapping):
         """
         Create a string representation of the AttrDict.
         """
-        return u"a{0}".format(repr(self._mapping))
+        return u"AttrDict({0})".format(repr(self._mapping))
 
     def __missing__(self, key):
         """


### PR DESCRIPTION
the __repr__ method of the object should return the syntax required to initialize said object.