### PR TITLE
Feat: `repr()` uses class name. Useful when subclassing Attrdict.

### DIFF
--- a/attrdict/default.py
+++ b/attrdict/default.py
@@ -88,8 +88,9 @@ class AttrDefault(MutableAttr):
         Return a string representation of the object.
         """
         return six.u(
-            "AttrDefault({default_factory}, {pass_key}, {mapping})"
+            "{name}({default_factory}, {pass_key}, {mapping})"
         ).format(
+            name=self.__class__.__name__,
             default_factory=repr(self._default_factory),
             pass_key=repr(self._pass_key),
             mapping=repr(self._mapping),

--- a/attrdict/dictionary.py
+++ b/attrdict/dictionary.py
@@ -45,7 +45,8 @@ class AttrDict(dict, MutableAttr):
         self._setattr('_allow_invalid_attributes', allow_invalid_attributes)
 
     def __repr__(self):
-        return six.u('AttrDict({contents})').format(
+        return six.u('{name}({contents})').format(
+            name=self.__class__.__name__,
             contents=super(AttrDict, self).__repr__()
         )
 

--- a/attrdict/mapping.py
+++ b/attrdict/mapping.py
@@ -68,7 +68,7 @@ class AttrMap(MutableAttr):
         # sequence type seems like more trouble than it is worth.
         # If people want full serialization, they can pickle, and in
         # 99% of cases, sequence_type won't change anyway
-        return six.u("AttrMap({mapping})").format(mapping=repr(self._mapping))
+        return six.u("{name}({mapping})").format(name=self.__class__.__name__, mapping=repr(self._mapping))
 
     def __getstate__(self):
         """

--- a/tests/test_attrdefault.py
+++ b/tests/test_attrdefault.py
@@ -50,3 +50,29 @@ def test_repr():
             ("AttrDefault(<", " 'list'>, True, {'foo': 'bar'})")
         )
     )
+
+def test_repr_subclass():
+    """
+    repr(AttrDefault)
+    """
+    from attrdict.default import AttrDefault
+
+    class MySubClass(AttrDefault):
+        pass
+
+    assert_equals(repr(MySubClass(None)), "MySubClass(None, False, {})")
+
+    # list's repr changes between python 2 and python 3
+    type_or_class = 'type' if PY2 else 'class'
+
+    assert_equals(
+        repr(MySubClass(list)),
+        type_or_class.join(("MySubClass(<", " 'list'>, False, {})"))
+    )
+
+    assert_equals(
+        repr(MySubClass(list, {'foo': 'bar'}, pass_key=True)),
+        type_or_class.join(
+            ("MySubClass(<", " 'list'>, True, {'foo': 'bar'})")
+        )
+    )

--- a/tests/test_attrdict.py
+++ b/tests/test_attrdict.py
@@ -114,6 +114,25 @@ def test_repr():
         "AttrDict({1: AttrDict({'foo': 'bar'})})"
     )
 
+def test_repr_subclass():
+    """
+    repr(AttrDict)
+    """
+
+    from attrdict.dictionary import AttrDict
+
+    class MySubClass(AttrDict):
+        pass
+
+    assert_equals(repr(MySubClass()), "MySubClass({})")
+    assert_equals(repr(MySubClass({'foo': 'bar'})), "MySubClass({'foo': 'bar'})")
+    assert_equals(
+        repr(MySubClass({1: {'foo': 'bar'}})), "MySubClass({1: {'foo': 'bar'}})"
+    )
+    assert_equals(
+        repr(MySubClass({1: MySubClass({'foo': 'bar'})})),
+        "MySubClass({1: MySubClass({'foo': 'bar'})})"
+    )
 
 if not PY2:
     def test_has_key():

--- a/tests/test_attrmap.py
+++ b/tests/test_attrmap.py
@@ -19,3 +19,22 @@ def test_repr():
         repr(AttrMap({1: AttrMap({'foo': 'bar'})})),
         "AttrMap({1: AttrMap({'foo': 'bar'})})"
     )
+
+def test_repr_subclass():
+    """
+    repr(AttrMap)
+    """
+    from attrdict.mapping import AttrMap
+
+    class MySubClass(AttrMap):
+        pass
+
+    assert_equals(repr(MySubClass()), "MySubClass({})")
+    assert_equals(repr(MySubClass({'foo': 'bar'})), "MySubClass({'foo': 'bar'})")
+    assert_equals(
+        repr(MySubClass({1: {'foo': 'bar'}})), "MySubClass({1: {'foo': 'bar'}})"
+    )
+    assert_equals(
+        repr(MySubClass({1: MySubClass({'foo': 'bar'})})),
+        "MySubClass({1: MySubClass({'foo': 'bar'})})"
+    )


### PR DESCRIPTION
I regularly use AttrDict to quickly convert JSON objects into what looks like native objects.

When getting the repr, it's nicer to see the subclassed name rather than `AttrDict`.

E.g.

```
>>> class MySubClass(AttrDict):
>>>    pass

>>> msc = AttrDict({})
>>> print(msc)
'MySubClass({})'

```
